### PR TITLE
Fixed URLs

### DIFF
--- a/dest/index.html
+++ b/dest/index.html
@@ -53,7 +53,7 @@
         <div class="col-md-3 building-image"></div>
         <div class="col-md-3">
           <div class="btn-group btn-group-vertical links" role="navigation" aria-label="Links to Moodle and Google Services" role="navigation">
-            <a href="https://moodle.port.ac.uk/" role="link" class="btn link link--moodle">
+            <a href="http://moodle.port.ac.uk/" role="link" class="btn link link--moodle">
               <span class="link-icon"></span>
               Moodle
             </a>
@@ -184,7 +184,7 @@
         </div>
         <div class="panel panel-secondary">
           <div class="panel-heading">
-            <a href="http://uopnews.port.ac.uk/student-events/" target="_blank">
+            <a href="http://uopnews.port.ac.uk/category/seeking-participants/" target="_blank">
               <h3 class="panel-title" role="columnheader">Seeking Participants</h3>
             </a>
           </div>
@@ -194,7 +194,7 @@
         </div>
         <div class="panel panel-secondary">
           <div class="panel-heading">
-            <a href="http://uopnews.port.ac.uk/category/seeking-participants/" target="_blank">
+            <a href="http://uopnews.port.ac.uk/student-events/" target="_blank">
               <h3 class="panel-title" role="columnheader">Events</h3>
             </a>
           </div>


### PR DESCRIPTION
Moodle moved back to http:// as https:// doesn't work correctly.
Swapped the Events and Seeking participants links.
